### PR TITLE
Reload the translation on the fly

### DIFF
--- a/djinn_i18n/views/reload.py
+++ b/djinn_i18n/views/reload.py
@@ -37,5 +37,13 @@ class ReloadView(IndexView, AdminMixin):
 
         except AttributeError, e:
             pass
+        
+        try:
+            from subprocess import Popen
+            from django.conf import settings
+            import os
+            Popen(["/bin/touch", os.path.join(settings.BASE_DIR, "wsgi.py")])
+        except Exception, e:
+            pass
 
         return super(ReloadView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
At the moment it is not possible to reload the translations without restarting the webserver.
With this change, the wsgi process is restarted when the reload button is clicked.
